### PR TITLE
Add support for rootPath: '/'

### DIFF
--- a/src/create-pages.js
+++ b/src/create-pages.js
@@ -1,3 +1,5 @@
+const path = require('path')
+
 module.exports = async ({ actions, graphql }, pluginOptions) => {
   const { createPage } = actions;
   const result = await graphql(`
@@ -28,7 +30,7 @@ module.exports = async ({ actions, graphql }, pluginOptions) => {
       });
     }
 
-    var notePath = `${rootPath}/${slug}`;
+    var notePath = path.join(rootPath, slug);
     createPage({
       path: notePath,
       component: require.resolve(noteTemplate),

--- a/src/source-nodes.js
+++ b/src/source-nodes.js
@@ -65,7 +65,7 @@ module.exports = (
       replacementMatches.forEach((match) => {
         var justText = match.match(regexExclusive)[0];
         var link = nameToSlugMap[justText.toLowerCase()];
-        var linkified = `[${match}](/${rootPath}/${link})`;
+        var linkified = `[${match}](${path.join(rootPath, link)})`;
         newRawContent = newRawContent.split(match).join(linkified);
       });
     }


### PR DESCRIPTION
I want my notes to show up at the top-level, but setting `rootPath: '/'` leads to the paths being `//${slug}`. Fixed by using `path.join` instead of naive string concatenation, which takes care of handling double slashes correctly! 👍