### PR TITLE
Use full match as the title and not the slug

### DIFF
--- a/src/source-nodes.js
+++ b/src/source-nodes.js
@@ -27,7 +27,7 @@ module.exports = (
           // Double check that the slugified version isn't already there
           slugToNoteMap[slug] = {
             slug: slug,
-            title: slug,
+            title: reference,
             content: "",
             rawContent: "",
             frontmatter: {


### PR DESCRIPTION
We currently use the `slug` as the title. It'd be nice if the title of the page is the exact match, like in Roam.