### PR TITLE
Adds safety check for outbound references.

### DIFF
--- a/src/source-nodes.js
+++ b/src/source-nodes.js
@@ -71,15 +71,19 @@ module.exports = (
       },
     };
     let outboundReferences = note.outboundReferences;
-    // Use the slug for easier use in queries
-    outboundReferences = outboundReferences.map((match) => {
-      return nameToSlugMap[match.toLowerCase()];
-    });
-    // Filter duplicates
-    outboundReferences = outboundReferences.filter(
-      (a, b) => outboundReferences.indexOf(a) === b
-    );
-    brainNoteNode.outboundReferences = outboundReferences;
+
+
+    if (outboundReferences) {
+      // Use the slug for easier use in queries
+      outboundReferences = outboundReferences.map((match) => {
+        return nameToSlugMap[match.toLowerCase()];
+      });
+      // Filter duplicates
+      outboundReferences = outboundReferences.filter(
+        (a, b) => outboundReferences.indexOf(a) === b
+      );
+      brainNoteNode.outboundReferences = outboundReferences;
+    }
 
     let inboundReferences = backlinkMap[slug];
     // For now removing duplicates because we don't give any other identifying information


### PR DESCRIPTION
I was getting some errors on nodes that didn't have outbound references with v1.0.4: 

```
"@aengusm/gatsby-theme-brain" threw an error while running the sourceNodes lifecycle:

Cannot read property 'map' of null
```

This resolved it for me!