### PR TITLE
default notesDirectory option and use @link directive for foreign key fields

### DIFF
--- a/src/create-schema-customization.js
+++ b/src/create-schema-customization.js
@@ -10,9 +10,9 @@ module.exports = ({ actions }) => {
       noteTemplate: String
       aliases: [String]
       outboundReferences: [String]
-      outboundReferenceNotes: [BrainNote]
+      outboundReferenceNotes: [BrainNote] @link(from: "outboundReferenceNotes___NODE")
       inboundReferences: [String]
-      inboundReferenceNotes: [BrainNote]
+      inboundReferenceNotes: [BrainNote] @link(from: "inboundReferenceNotes___NODE")
       inboundReferencePreview: [InboundReferencePreview]
       childMdx: Mdx
     }

--- a/src/source-nodes.js
+++ b/src/source-nodes.js
@@ -152,7 +152,8 @@ module.exports = (api, pluginOptions) => {
     pluginOptions
   );
 
-  const watchPath = path.resolve(process.cwd(), pluginOptions.notesDirectory);
+  const notesDirectory = pluginOptions.notesDirectory || "content/brain/";
+  const watchPath = path.resolve(process.cwd(), notesDirectory);
   const watcher = chokidar.watch(watchPath);
 
   watcher.on(`add`, (path) => {


### PR DESCRIPTION
## notesDirectory bug
Got an error after the new HRM changes when not providing a notesDirectory option, because `path.resolve` was being passed `undefined`. Fixed by defaulting the option.

```
 ERROR #11321  PLUGIN

"@aengusm/gatsby-theme-brain" threw an error while running the sourceNodes lifecycle:

The "path" argument must be of type string. Received undefined


  Error: TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received undefined
  
  - validators.js:117 validateString
    internal/validators.js:117:11
  
  - source-nodes.js:155 Object.module.exports [as sourceNodes]
    [personal]/[@aengusm]/gatsby-theme-brain/src/source-nodes.js:155:26
```

## Foreign key fields bug
Also was having issues with `inboundReferenceNotes` and `outboundReferenceNotes` fields after the `@infer` directive was added. I'm not super familiar with Gatsby plugin authoring, but the [docs](https://www.gatsbyjs.org/docs/schema-customization/#foreign-key-fields) had a note to use the `@link` directive to specify foreign key fields in newer versions of Gatsby and it fixed the issue for me.