### PR TITLE
pass default function to logging

### DIFF
--- a/src/source-nodes.js
+++ b/src/source-nodes.js
@@ -66,7 +66,8 @@ const createFSMachine = (
       id: "delayTimer", // give the event a unique ID
     });
   } else {
-    sendTimerAfterDelay = log();
+    const defaultLog = (_, ...args) => `unset logging with ${args}`;
+    sendTimerAfterDelay = log(defaultLog);
   }
 
   const cancelTimer = cancel("delayTimer"); // pass the ID of event to cancel


### PR DESCRIPTION
Fixes #34 

## Rationale
- When [this line gets called](https://github.com/JuanCaicedo/gatsby-theme-brain/blob/master/src/source-nodes.js#L57), it always expects that `expr` will be a function
- This was the only case where it wasn't

## Other info
- I noticed this behavior only when running off `master`
  - It seems strange that the version installed from npm doesn't cause this problem
  - After looking at the files included in the npm version, I think that there are unpublished changes in the master branch