### PR TITLE
Slugify filenames to allow for spaces

### DIFF
--- a/src/get-markdown-notes.js
+++ b/src/get-markdown-notes.js
@@ -1,5 +1,6 @@
 const fs = require("fs");
 const path = require("path");
+const generateSlug = require("./generate-slug");
 
 function toRegExp(value) {
   if (typeof value === "string") {
@@ -31,7 +32,7 @@ module.exports = (pluginOptions) => {
     .map((filename) => {
       let slug = pluginOptions.generateSlug
         ? pluginOptions.generateSlug(filename)
-        : path.parse(filename).name.toLowerCase();
+        : generateSlug(path.parse(filename).name);
 
       let fullPath = notesDirectory + filename;
 


### PR DESCRIPTION
This will fix a couple of issues coming up for files with spaces in the name. Links with spaces in it don't work well, which was causing issues when files were added with a space in the filename.

This changes it so those files have a slug generated that strips out certain things, and converts white space to dashes. This might lead to file naming conflicts if there is, for example 'test post.md' and 'test-post.md', but I'm assuming this won't be a common case, so for now this should be a safe option.