### PR TITLE
Fixed inboundReferencePreview typo in GraphQL schema

### DIFF
--- a/src/create-schema-customization.js
+++ b/src/create-schema-customization.js
@@ -13,7 +13,7 @@ module.exports = ({ actions }) => {
       outboundReferenceNotes: [BrainNote] @link(from: "outboundReferenceNotes___NODE")
       inboundReferences: [String]
       inboundReferenceNotes: [BrainNote] @link(from: "inboundReferenceNotes___NODE")
-      inboundReferencePreview: [InboundReferencePreview]
+      inboundReferencePreviews: [InboundReferencePreview]
       externalInboundReferences: [ExternalInboundReference]
       externalOutboundReferences: [ExternalOutboundReference]
       childMdx: Mdx


### PR DESCRIPTION
Otherwise I get an error that `inboundReferencePreviews` can't be found.