### PR TITLE
Subdirectories support under the 'content' directory…

### DIFF
--- a/src/get-markdown-notes.js
+++ b/src/get-markdown-notes.js
@@ -13,6 +13,27 @@ const matches = (filename) => (regExp) => regExp.test(filename);
 const doesNotMatchAny = (regExps) => (filename) =>
   !regExps.some(matches(filename));
 
+
+var walkSync = function(baseDir, filelist, subDir) {
+  subDir = subDir || "";
+  var fs = fs || require('fs');
+  var filelist = filelist || [];
+  var path = path || require('path');
+  var files = fs.readdirSync(path.join(baseDir, subDir));
+
+  files.forEach(function(file) {
+    if (file[0] === ".") return;
+    let fileIsDirectory = fs.statSync(path.join(baseDir, subDir, file)).isDirectory();
+    if (fileIsDirectory) {
+      filelist = walkSync(baseDir, filelist, path.join(subDir, file));
+    } else {
+      filelist.push(path.join(subDir, file));
+    }
+  });
+  return filelist;
+};
+
+
 module.exports = (pluginOptions) => {
   let notesDirectory = pluginOptions.notesDirectory || "content/brain/";
   let notesFileExtensions = pluginOptions.notesFileExtensions || [
@@ -22,7 +43,8 @@ module.exports = (pluginOptions) => {
   let exclusions =
     (pluginOptions.exclude && pluginOptions.exclude.map(toRegExp)) || [];
 
-  let filenames = fs.readdirSync(notesDirectory);
+  // let filenames = fs.readdirSync(notesDirectory);
+  let filenames = walkSync(notesDirectory);
 
   return filenames
     .filter((filename) => {


### PR DESCRIPTION
I've updated the file listing function to identify all the files located under the "content" directory, so it not only scans the root directory, but also walks through all the subdirectories to find files.

This way, the users can organise their notes in a better matter.