### PR TITLE
 posix join to avoid errors on windows

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -38,7 +38,7 @@ module.exports = ({
               return notes.nodes.map((note) => {
                 let notePath = url.resolve(
                   site.siteMetadata.siteUrl,
-                  path.join(rootPath, note.slug)
+                  path.posix.join(rootPath, note.slug)
                 );
                 return Object.assign({}, note.childMdx.frontmatter, {
                   description: note.childMdx.excerpt,
@@ -52,7 +52,7 @@ module.exports = ({
             query: `
             {
               notes: allBrainNote(
-                filter: {childMdx: {frontmatter: {syndicate: {eq: true}}}}, 
+                filter: {childMdx: {frontmatter: {syndicate: {eq: true}}}},
                 sort: {fields: childMdx___frontmatter___date, order: DESC}
               ) {
                 nodes {

--- a/src/create-pages.js
+++ b/src/create-pages.js
@@ -33,7 +33,7 @@ module.exports = async ({ actions, graphql }, pluginOptions) => {
       });
     }
 
-    let notePath = path.join(rootPath, slug);
+    let notePath = path.posix.join(rootPath, slug);
     createPage({
       path: notePath,
       component: path.resolve(note.noteTemplate),

--- a/src/source-nodes.js
+++ b/src/source-nodes.js
@@ -365,7 +365,7 @@ function generateNodes(
       note.content,
       nameToSlugMap,
       externalRefMap,
-      path.join("/", rootPath, "/"),
+      path.posix.join("/", rootPath, "/"),
       pluginOptions
     );
 
@@ -407,7 +407,7 @@ function generateNodes(
           previewMarkdown,
           nameToSlugMap,
           externalRefMap,
-          path.join("/", rootPath, "/"),
+          path.posix.join("/", rootPath, "/"),
           pluginOptions
         );
 


### PR DESCRIPTION
In order to have consistent slug creation across Unix and Windows machines, we can use `path.posix.join()` instead of just `path.join()`. Otherwise, pages are generated incorrectly when built on Windows machines. Closes #49 